### PR TITLE
Merge 3.0.0-beta8 changes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,6 +80,7 @@
         "type": "process",
         "args": [
             "build",
+            "-c", "Release",
             "${workspaceFolder}/src/dotnet/StreamXRefTypes.csproj",
             "/property:GenerateFullPaths=true",
             "/consoleloggerparameters:NoSummary"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -73,6 +73,18 @@
         ]
       },
       "problemMatcher": []
+    },
+    {
+        "label": "Build .NET assembly",
+        "command": "dotnet",
+        "type": "process",
+        "args": [
+            "build",
+            "${workspaceFolder}/src/dotnet/StreamXRefTypes.csproj",
+            "/property:GenerateFullPaths=true",
+            "/consoleloggerparameters:NoSummary"
+        ],
+        "problemMatcher": "$msCompile"
     }
   ]
 }

--- a/Module/PSCurrent/Find-TwitchXRef.ps1
+++ b/Module/PSCurrent/Find-TwitchXRef.ps1
@@ -130,7 +130,7 @@ function Find-TwitchXRef {
             $OffsetArgs["Minutes"] = $Matches.ContainsKey("Minutes") ? $Matches.Minutes : 0
             $OffsetArgs["Seconds"] = $Matches.ContainsKey("Seconds") ? $Matches.Seconds : 0
 
-            [timespan]$TimeOffset = New-TimeSpan @OffsetArgs
+            $TimeOffset = New-TimeSpan @OffsetArgs
             #endregion
 
             [int]$VideoID = $Source | Get-LastUrlSegment
@@ -144,8 +144,6 @@ function Find-TwitchXRef {
             # Strip potential URL formatting
             $Slug = $Source | Get-LastUrlSegment
 
-            $tmpFlagCached = $false
-
             if (-not $Force -and $script:TwitchData.ClipInfoCache.ContainsKey($Slug)) {
                 # Found cached values to use
 
@@ -155,28 +153,18 @@ function Find-TwitchXRef {
                     return $script:TwitchData.ClipInfoCache[$Slug].Mapping[$XRef]
 
                 }
+                else {
 
-                try {
-
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
-                    [int]$VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
+                    $TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
+                    $VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
 
                     # Set REST arguments
                     $RestArgs["Uri"] = "$API/videos/$VideoID"
 
-                    $tmpFlagCached = $true
-
-                }
-                catch {
-
-                    # Suppress error output because the fallback will be to just look up the value again
-                    [void] $_
-
                 }
 
             }
-
-            if (-not $tmpFlagCached) {
+            else {
                 # New uncached source ---- needs additional API call
 
                 # Get information about clip
@@ -193,7 +181,7 @@ function Find-TwitchXRef {
                     }
 
                     # Get offset from API response
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
+                    $TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
 
                     # Get Video ID from API response
                     [int]$VideoID = $ClipResponse.vod.id
@@ -265,7 +253,7 @@ function Find-TwitchXRef {
         if (-not $Force -and $script:TwitchData.VideoInfoCache.ContainsKey($VideoID)) {
 
             # Use start time from cache
-            [datetime]$EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
+            $EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
 
         }
         else {
@@ -359,7 +347,7 @@ function Find-TwitchXRef {
             if (-not $Force -and $script:TwitchData.UserInfoCache.ContainsKey($XRef)) {
 
                 # Get cached ID number
-                [int]$UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
+                $UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
 
             }
             else {

--- a/Module/PSCurrent/Find-TwitchXRef.ps1
+++ b/Module/PSCurrent/Find-TwitchXRef.ps1
@@ -100,10 +100,6 @@ function Find-TwitchXRef {
             ErrorAction = "Stop"
         }
 
-        # Standardize input to lowercase
-        $Source = $Source.ToLowerInvariant()
-        $XRef = $XRef.ToLowerInvariant()
-
         # Initial basic sorting
         $SourceIsVideo = $Source -imatch ".*twitch\.tv/videos/.+" ? $true : $false
         $XRefIsVideo = $XRef -imatch ".*twitch\.tv/videos/.+" ? $true : $false
@@ -209,20 +205,19 @@ function Find-TwitchXRef {
 
                     }
 
-                    # Populate the Clip to Username hashtable with the originating video
-                    $ClipMapping = @{}
-                    $ClipMapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
-
                     # Ensure timestamp was converted correctly
                     $ClipResponse.created_at = $ClipResponse.created_at | ConvertTo-UtcDateTime
 
                     # Add data to clip cache
-                    $script:TwitchData.ClipInfoCache[$Slug] = [PSCustomObject]@{
+                    $script:TwitchData.ClipInfoCache[$Slug] = [StreamXRef.ClipObject]@{
                         Offset  = $ClipResponse.vod.offset
                         VideoID = $VideoID
                         Created = $ClipResponse.created_at
-                        Mapping = $ClipMapping
                     }
+
+                    # Add mapping for originating video to clip entry
+                    $script:TwitchData.ClipInfoCache[$Slug].Mapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
+
                     $NewDataAdded = $true
 
                     # Quick return path for when XRef is original broadcaster

--- a/Module/PSCurrent/Find-TwitchXRef.ps1
+++ b/Module/PSCurrent/Find-TwitchXRef.ps1
@@ -49,12 +49,6 @@ function Find-TwitchXRef {
 
     Begin {
 
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         $API = "https://api.twitch.tv/kraken"
 
         if ($PSBoundParameters.ContainsKey("ApiKey")) {

--- a/Module/PSCurrent/Find-TwitchXRef.ps1
+++ b/Module/PSCurrent/Find-TwitchXRef.ps1
@@ -133,7 +133,7 @@ function Find-TwitchXRef {
             }
 
             #region Get offset from URL parameters
-            [void]($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
+            [void] ($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
 
             $OffsetArgs = @{ }
             $OffsetArgs["Hours"] = $Matches.ContainsKey("Hours") ? $Matches.Hours : 0
@@ -180,7 +180,7 @@ function Find-TwitchXRef {
                 catch {
 
                     # Suppress error output because the fallback will be to just look up the value again
-                    [void]$_
+                    [void] $_
 
                 }
 

--- a/Module/PSCurrent/Find-TwitchXRef.ps1
+++ b/Module/PSCurrent/Find-TwitchXRef.ps1
@@ -543,7 +543,7 @@ function Find-TwitchXRef {
 
         if ((Get-EventSubscriber -SourceIdentifier XRefNewDataAdded -Force -ErrorAction Ignore) -and $NewDataAdded) {
 
-            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender StreamXRef)
+            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender "Find-TwitchXRef")
 
         }
 

--- a/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
+++ b/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
@@ -144,7 +144,7 @@ function Find-TwitchXRef {
             }
 
             #region Get offset from URL parameters
-            [void]($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
+            [void] ($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
 
             $OffsetArgs = @{
                 Hours = 0
@@ -201,7 +201,7 @@ function Find-TwitchXRef {
                 catch {
 
                     # Suppress error output because the fallback will be to just look up the value again
-                    [void]$_
+                    [void] $_
 
                 }
 

--- a/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
+++ b/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
@@ -49,12 +49,6 @@ function Find-TwitchXRef {
 
     Begin {
 
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         $API = "https://api.twitch.tv/kraken"
 
         if ($PSBoundParameters.ContainsKey("ApiKey")) {

--- a/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
+++ b/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
@@ -100,10 +100,6 @@ function Find-TwitchXRef {
             ErrorAction = "Stop"
         }
 
-        # Standardize input to lowercase
-        $Source = $Source.ToLowerInvariant()
-        $XRef = $XRef.ToLowerInvariant()
-
         # Initial basic sorting
         if ($Source -imatch ".*twitch\.tv/videos/.+") {
             $SourceIsVideo = $true
@@ -230,20 +226,19 @@ function Find-TwitchXRef {
 
                     }
 
-                    # Populate the Clip to Username hashtable with the originating video
-                    $ClipMapping = @{}
-                    $ClipMapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
-
                     # Ensure timestamp was converted correctly
                     $ClipResponse.created_at = $ClipResponse.created_at | ConvertTo-UtcDateTime
 
                     # Add data to clip cache
-                    $script:TwitchData.ClipInfoCache[$Slug] = [PSCustomObject]@{
+                    $script:TwitchData.ClipInfoCache[$Slug] = [StreamXRef.ClipObject]@{
                         Offset  = $ClipResponse.vod.offset
                         VideoID = $VideoID
                         Created = $ClipResponse.created_at
-                        Mapping = $ClipMapping
                     }
+
+                    # Add mapping for originating video to clip entry
+                    $script:TwitchData.ClipInfoCache[$Slug].Mapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
+
                     $NewDataAdded = $true
 
                     # Quick return path for when XRef is original broadcaster

--- a/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
+++ b/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
@@ -578,7 +578,7 @@ function Find-TwitchXRef {
 
         if ((Get-EventSubscriber -SourceIdentifier XRefNewDataAdded -Force -ErrorAction Ignore) -and $NewDataAdded) {
 
-            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender StreamXRef)
+            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender "Find-TwitchXRef")
 
         }
 

--- a/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
+++ b/Module/PSLegacy/Find-TwitchXRef.Legacy.ps1
@@ -151,7 +151,7 @@ function Find-TwitchXRef {
                 $OffsetArgs["Seconds"] = $Matches.Seconds
             }
 
-            [timespan]$TimeOffset = New-TimeSpan @OffsetArgs
+            $TimeOffset = New-TimeSpan @OffsetArgs
             #endregion
 
             [int]$VideoID = $Source | Get-LastUrlSegment
@@ -165,8 +165,6 @@ function Find-TwitchXRef {
             # Strip potential URL formatting
             $Slug = $Source | Get-LastUrlSegment
 
-            $tmpFlagCached = $false
-
             if (-not $Force -and $script:TwitchData.ClipInfoCache.ContainsKey($Slug)) {
                 # Found cached values to use
 
@@ -176,28 +174,18 @@ function Find-TwitchXRef {
                     return $script:TwitchData.ClipInfoCache[$Slug].Mapping[$XRef]
 
                 }
+                else {
 
-                try {
-
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
-                    [int]$VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
+                    $TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
+                    $VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
 
                     # Set REST arguments
                     $RestArgs["Uri"] = "$API/videos/$VideoID"
 
-                    $tmpFlagCached = $true
-
-                }
-                catch {
-
-                    # Suppress error output because the fallback will be to just look up the value again
-                    [void] $_
-
                 }
 
             }
-
-            if (-not $tmpFlagCached) {
+            else {
                 # New uncached source ---- needs additional API call
 
                 # Get information about clip
@@ -214,7 +202,7 @@ function Find-TwitchXRef {
                     }
 
                     # Get offset from API response
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
+                    $TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
 
                     # Get Video ID from API response
                     [int]$VideoID = $ClipResponse.vod.id
@@ -286,7 +274,7 @@ function Find-TwitchXRef {
         if (-not $Force -and $script:TwitchData.VideoInfoCache.ContainsKey($VideoID)) {
 
             # Use start time from cache
-            [datetime]$EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
+            $EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
 
         }
         else {
@@ -389,7 +377,7 @@ function Find-TwitchXRef {
             if (-not $Force -and $script:TwitchData.UserInfoCache.ContainsKey($XRef)) {
 
                 # Get cached ID number
-                [int]$UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
+                $UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
 
             }
             else {

--- a/Module/Shared/Clear-XRefData.ps1
+++ b/Module/Shared/Clear-XRefData.ps1
@@ -17,16 +17,6 @@ function Clear-XRefData {
         [switch]$RemoveAll
     )
 
-    Begin {
-
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
-    }
-
     Process {
 
         if ($RemoveAll) {

--- a/Module/Shared/Clear-XRefData.ps1
+++ b/Module/Shared/Clear-XRefData.ps1
@@ -67,7 +67,7 @@ function Clear-XRefData {
                     [string[]]$PurgeList = $script:TwitchData.ClipInfoCache.GetEnumerator() |
                     Where-Object { $_.Value.Created -lt $Cutoff } | Select-Object -ExpandProperty Key
 
-                    [void]($PurgeList | ForEach-Object { $script:TwitchData.ClipInfoCache.Remove($_) })
+                    [void] ($PurgeList | ForEach-Object { $script:TwitchData.ClipInfoCache.Remove($_) })
 
                     # Getting the count this way in case removing an entry somehow fails
                     Write-Verbose "(Clip) Data entries removed: $($PreviousCount - $script:TwitchData.ClipInfoCache.Count)"
@@ -82,7 +82,7 @@ function Clear-XRefData {
                     [string[]]$PurgeList = $script:TwitchData.VideoInfoCache.GetEnumerator() |
                         Where-Object { $_.Value -lt $Cutoff } | Select-Object -ExpandProperty Key
 
-                    [void]($PurgeList | ForEach-Object { $script:TwitchData.VideoInfoCache.Remove($_) })
+                    [void] ($PurgeList | ForEach-Object { $script:TwitchData.VideoInfoCache.Remove($_) })
 
                     # Getting the count this way in case removing an entry somehow fails
                     Write-Verbose "(Video) Data entries removed: $($PreviousCount - $script:TwitchData.VideoInfoCache.Count)"

--- a/Module/Shared/Disable-XRefPersistence.ps1
+++ b/Module/Shared/Disable-XRefPersistence.ps1
@@ -12,7 +12,7 @@ function Disable-XRefPersistence {
 
     Process {
 
-        if ($PersistStatus.CanUse) {
+        if ($PersistCanUse) {
 
             if ($Remove) {
 
@@ -41,12 +41,12 @@ function Disable-XRefPersistence {
             }
 
             # Disable persistence subscriber
-            if ($PersistStatus.Id -ne 0) {
+            if ($PersistId -ne 0) {
 
-                Unregister-Event -SubscriptionId $PersistStatus.Id
+                Unregister-Event -SubscriptionId $PersistId
 
                 # Reset value
-                $script:PersistStatus.Id = 0
+                $script:PersistId = 0
 
                 if (-not $Quiet) {
                     Write-Host "StreamXRef persistence disabled."
@@ -54,7 +54,7 @@ function Disable-XRefPersistence {
 
             }
 
-            $script:PersistStatus.Enabled = $false
+            $script:PersistEnabled = $false
 
         }
         else {

--- a/Module/Shared/Enable-XRefPersistence.ps1
+++ b/Module/Shared/Enable-XRefPersistence.ps1
@@ -9,9 +9,9 @@ function Enable-XRefPersistence {
 
     Process {
 
-        if ($PersistStatus.CanUse) {
+        if ($PersistCanUse) {
 
-            if ($PersistStatus.Enabled) {
+            if ($PersistEnabled) {
 
                 if (-not $Quiet) {
                     Write-Host "StreamXRef persistence is already enabled."
@@ -58,9 +58,9 @@ function Enable-XRefPersistence {
                 })
 
                 # Take note of the subscription id (might not be the same as the PSEventJob id)
-                $script:PersistStatus.Id = (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded | Select-Object -Last 1).SubscriptionId
+                $script:PersistId = (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded | Select-Object -Last 1).SubscriptionId
 
-                $script:PersistStatus.Enabled = $true
+                $script:PersistEnabled = $true
 
                 if (-not $Quiet) {
                     Write-Host -BackgroundColor Black -ForegroundColor Green "StreamXRef persistence enabled."

--- a/Module/Shared/Export-XRefData.ps1
+++ b/Module/Shared/Export-XRefData.ps1
@@ -1,3 +1,4 @@
+using namespace System.Collections.Generic
 #.ExternalHelp StreamXRef-help.xml
 function Export-XRefData {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
@@ -47,6 +48,9 @@ function Export-XRefData {
 
         }
 
+        # DateTime string formatting ("yyyy-MM-ddTHH:mm:ssZ" -> "2020-05-09T05:35:45Z")
+        $DateTimeFormatting = "yyyy-MM-ddTHH:mm:ssZ"
+
         # Handle API key
         if ($ExcludeApiKey) {
             $ExportApiKey = ""
@@ -55,9 +59,9 @@ function Export-XRefData {
             $ExportApiKey = $script:TwitchData.ApiKey
         }
 
-        $ConvertedUserInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
-        $ConvertedClipInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
-        $ConvertedVideoInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
+        $ConvertedUserInfoCache = [List[pscustomobject]]::new()
+        $ConvertedClipInfoCache = [List[pscustomobject]]::new()
+        $ConvertedVideoInfoCache = [List[pscustomobject]]::new()
 
         # Convert UserInfoCache to List
         $script:TwitchData.UserInfoCache.GetEnumerator() | ForEach-Object {
@@ -74,7 +78,7 @@ function Export-XRefData {
         # Convert ClipInfoCache to List
         $script:TwitchData.ClipInfoCache.GetEnumerator() | ForEach-Object {
 
-            $ClipInfoMapping = [System.Collections.Generic.List[pscustomobject]]::new()
+            $ClipInfoMapping = [List[pscustomobject]]::new()
 
             if (-not $ExcludeClipMapping) {
                 # Convert clip mapping data to List
@@ -93,7 +97,7 @@ function Export-XRefData {
                     slug    = $_.Key
                     offset  = $_.Value.Offset
                     video   = $_.Value.VideoID
-                    created = $_.Value.Created.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                    created = $_.Value.Created.ToString($DateTimeFormatting)
                     mapping = $ClipInfoMapping
                 }
             )
@@ -103,11 +107,10 @@ function Export-XRefData {
         # Convert VideoInfoCache to List
         $script:TwitchData.VideoInfoCache.GetEnumerator() | ForEach-Object {
 
-            # ToString("yyyy-MM-ddTHH:mm:ssZ") specifies format like "2020-05-09T05:35:45Z"
             $ConvertedVideoInfoCache.Add(
                 [pscustomobject]@{
                     video     = $_.Key
-                    timestamp = $_.Value.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                    timestamp = $_.Value.ToString($DateTimeFormatting)
                 }
             )
 

--- a/Module/Shared/Export-XRefData.ps1
+++ b/Module/Shared/Export-XRefData.ps1
@@ -30,12 +30,6 @@ function Export-XRefData {
 
     Begin {
 
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         if ([string]::IsNullOrWhiteSpace($script:TwitchData.ApiKey) -and $script:TwitchData.GetTotalCount() -eq 0) {
 
             Write-Warning "No cached data. Exported file will not contain any entries."

--- a/Module/Shared/Import-XRefData.ps1
+++ b/Module/Shared/Import-XRefData.ps1
@@ -30,13 +30,6 @@ function Import-XRefData {
 
         }
 
-        # Check for required resources
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         $MappingWarning = $false
         $ConflictingData = $false
 
@@ -53,21 +46,11 @@ function Import-XRefData {
             # This will now terminate the script if it fails
             $ConfigStaging = Get-Content $Path -Raw | ConvertFrom-Json
 
-            if ($AdvImportCounter) {
-                # Set up counters object
-                $Counters = [StreamXRef.ImportResults]::new()
-                $Counters.AddCounter("User")
-                $Counters.AddCounter("Clip")
-                $Counters.AddCounter("Video")
-            }
-            else {
-                # Basic fallback object
-                $Counters = @{
-                    User = [pscustomobject]@{Name = "User"; Imported = 0; Skipped = 0; Error = 0}
-                    Clip = [pscustomobject]@{Name = "Clip"; Imported = 0; Skipped = 0; Error = 0}
-                    Video = [pscustomobject]@{Name = "Video"; Imported = 0; Skipped = 0; Error = 0}
-                }
-            }
+            # Set up counters object
+            $Counters = [StreamXRef.ImportResults]::new()
+            $Counters.AddCounter("User")
+            $Counters.AddCounter("Clip")
+            $Counters.AddCounter("Video")
 
             # Restore ErrorActionPreference
             $ErrorActionPreference = $EAPrefSetting
@@ -469,8 +452,7 @@ function Import-XRefData {
 
             if (-not $Quiet) {
 
-                # Display import results (manual ordering in case of unordered fallback object)
-                ($Counters.User, $Counters.Clip, $Counters.Video) | Format-Table -AutoSize | Out-Host
+                $Counters.Values| Format-Table -AutoSize | Out-Host
 
             }
 

--- a/Module/Shared/Import-XRefData.ps1
+++ b/Module/Shared/Import-XRefData.ps1
@@ -44,7 +44,7 @@ function Import-XRefData {
             $ErrorActionPreference = "Stop"
 
             # This will now terminate the script if it fails
-            $ConfigStaging = Get-Content $Path -Raw | ConvertFrom-Json
+            $ImportStaging = Get-Content $Path -Raw | ConvertFrom-Json
 
             # Set up counters object
             $Counters = [StreamXRef.ImportResults]::new()
@@ -58,7 +58,7 @@ function Import-XRefData {
         }
 
         # Process ApiKey (Check parameter set first since ConfigStaging won't exist in the ApiKey set)
-        if ($PSCmdlet.ParameterSetName -eq "ApiKey" -or ($ConfigStaging.psobject.Properties.Name -contains "ApiKey" -and -not [string]::IsNullOrWhiteSpace($ConfigStaging.ApiKey))) {
+        if ($PSCmdlet.ParameterSetName -eq "ApiKey" -or ($ImportStaging.psobject.Properties.Name -contains "ApiKey" -and -not [string]::IsNullOrWhiteSpace($ImportStaging.ApiKey))) {
 
             # Check if current API key is not set
             if ([string]::IsNullOrWhiteSpace($script:TwitchData.ApiKey)) {
@@ -84,7 +84,7 @@ function Import-XRefData {
                     else {
 
                         # Import API key from input object
-                        $script:TwitchData.ApiKey = $ConfigStaging.ApiKey
+                        $script:TwitchData.ApiKey = $ImportStaging.ApiKey
 
                         if (-not $Quiet) {
 
@@ -109,7 +109,7 @@ function Import-XRefData {
                 else {
 
                     # Get key from input object
-                    $NewApiKey = $ConfigStaging.ApiKey
+                    $NewApiKey = $ImportStaging.ApiKey
 
                 }
 
@@ -154,12 +154,12 @@ function Import-XRefData {
         }
 
         # Process UserInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "UserInfoCache" -and $ConfigStaging.UserInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "UserInfoCache" -and $ImportStaging.UserInfoCache.Count -gt 0) {
 
             # Check for confirm status here instead of for every single entry
             if ($PSCmdlet.ShouldProcess("User ID lookup data", "Import")) {
 
-                $ConfigStaging.UserInfoCache | ForEach-Object {
+                $ImportStaging.UserInfoCache | ForEach-Object {
 
                     try {
 
@@ -237,11 +237,11 @@ function Import-XRefData {
         }
 
         # Process ClipInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "ClipInfoCache" -and $ConfigStaging.ClipInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "ClipInfoCache" -and $ImportStaging.ClipInfoCache.Count -gt 0) {
 
             if ($PSCmdlet.ShouldProcess("Clip info lookup data", "Import")) {
 
-                $ConfigStaging.ClipInfoCache | ForEach-Object {
+                $ImportStaging.ClipInfoCache | ForEach-Object {
 
                     try {
 
@@ -346,11 +346,11 @@ function Import-XRefData {
         }
 
         # Process VideoInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "VideoInfoCache" -and $ConfigStaging.VideoInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "VideoInfoCache" -and $ImportStaging.VideoInfoCache.Count -gt 0) {
 
             if ($PSCmdlet.ShouldProcess("Video timestamp lookup data", "Import")) {
 
-                $ConfigStaging.VideoInfoCache | ForEach-Object {
+                $ImportStaging.VideoInfoCache | ForEach-Object {
 
                     try {
 

--- a/Module/Shared/Import-XRefData.ps1
+++ b/Module/Shared/Import-XRefData.ps1
@@ -16,6 +16,9 @@ function Import-XRefData {
         [switch]$PassThru,
 
         [Parameter()]
+        [switch]$Persist,
+
+        [Parameter()]
         [switch]$Quiet,
 
         [Parameter()]
@@ -442,6 +445,16 @@ function Import-XRefData {
             if (-not $Quiet) {
 
                 $Counters.Values| Format-Table -AutoSize | Out-Host
+
+            }
+
+            if ($Persist -and $Counters.AllImported -gt 0) {
+
+                if (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded -Force -ErrorAction Ignore) {
+
+                    [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender "Import-XRefData")
+
+                }
 
             }
 

--- a/Module/Shared/Import-XRefData.ps1
+++ b/Module/Shared/Import-XRefData.ps1
@@ -278,7 +278,7 @@ function Import-XRefData {
                                 if ($Force) {
 
                                     # Overwrite
-                                    $script:TwitchData.ClipInfoCache[$_.slug] = [pscustomobject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
+                                    $script:TwitchData.ClipInfoCache[$_.slug] = [StreamXRef.ClipObject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
                                     $Counters.Clip.Imported++
 
                                 }
@@ -305,7 +305,7 @@ function Import-XRefData {
                         else {
 
                             # New data to add
-                            $script:TwitchData.ClipInfoCache[$_.slug] = [pscustomobject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
+                            $script:TwitchData.ClipInfoCache[$_.slug] = [StreamXRef.ClipObject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
                             $Counters.Clip.Imported++
 
                         }

--- a/Module/Shared/Import-XRefData.ps1
+++ b/Module/Shared/Import-XRefData.ps1
@@ -119,28 +119,17 @@ function Import-XRefData {
                     # Specify "Replace" since previous value will be replaced
                     if ($PSCmdlet.ShouldProcess("API key", "Replace")) {
 
-                        if ($PSCmdlet.ParameterSetName -eq "ApiKey") {
+                        $script:TwitchData.ApiKey = $NewApiKey
 
-                            $script:TwitchData.ApiKey = $NewApiKey
+                        if (-not $Quiet) {
 
-                            if (-not $Quiet) {
-
-                                Write-Host "API key replaced."
-
-                            }
-
-                            return
+                            Write-Host "API key replaced."
 
                         }
-                        else {
 
-                            $script:TwitchData.ApiKey = $NewApiKey
+                        if ($PSCmdlet.ParameterSetName -eq "ApiKey") {
 
-                            if (-not $Quiet) {
-
-                                Write-Host "API key replaced."
-
-                            }
+                            return
 
                         }
 

--- a/Module/StreamXRef-help.xml
+++ b/Module/StreamXRef-help.xml
@@ -865,12 +865,12 @@ https://www.twitch.tv/videos/122333444?t=1h04m42s</dev:code>
       <command:verb>Import</command:verb>
       <command:noun>XRefData</command:noun>
       <maml:description>
-        <maml:para>Import data to the lookup cache. Can also set the API key without invoking a full lookup.</maml:para>
+        <maml:para>Import data to the lookup cache.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
       <maml:para>This command lets you import data into the lookup cache from a JSON file that was made using `Export-XRefData`. If you use the `ApiKey` parameter, you can instead import just your API key from a string without having to invoke the main `Find-TwitchXRef` command.</maml:para>
-      <maml:para>This command DOES NOT send an " XRefNewDataAdded " event.</maml:para>
+      <maml:para>This command does not send an " XRefNewDataAdded " event by default.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -891,6 +891,28 @@ https://www.twitch.tv/videos/122333444?t=1h04m42s</dev:code>
           <maml:name>Force</maml:name>
           <maml:Description>
             <maml:para>Forces overwriting of existing data in the Clip, User, and Video lookup caches.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Persist</maml:name>
+          <maml:Description>
+            <maml:para>Enables sending an XRefNewDataAdded event after new data is imported if there's a registered event subscriber (or if persistence is enabled).</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Quiet</maml:name>
+          <maml:Description>
+            <maml:para>Suppress writing import results to host as well as per-item warning messages (but not errors).</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -950,6 +972,17 @@ https://www.twitch.tv/videos/122333444?t=1h04m42s</dev:code>
           <maml:name>PassThru</maml:name>
           <maml:Description>
             <maml:para>When specified, this function will return an object with the results of the import.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Persist</maml:name>
+          <maml:Description>
+            <maml:para>Enables sending an XRefNewDataAdded event after new data is imported if there's a registered event subscriber (or if persistence is enabled).</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1033,6 +1066,18 @@ https://www.twitch.tv/videos/122333444?t=1h04m42s</dev:code>
         <maml:name>PassThru</maml:name>
         <maml:Description>
           <maml:para>When specified, this function will return an object with the results of the import.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Persist</maml:name>
+        <maml:Description>
+          <maml:para>Enables sending an XRefNewDataAdded event after new data is imported if there's a registered event subscriber (or if persistence is enabled).</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/Module/StreamXRef.psd1
+++ b/Module/StreamXRef.psd1
@@ -52,7 +52,7 @@ First version released as a full PowerShell Module.
 * Added `Export-XRefData`, `Import-XRefData`, `Clear-XRefData`, `Enable-XRefPersistence`, and `Disable-XRefPersistence`
 '@
 
-            Prerelease = 'beta7'
+            Prerelease = 'beta8'
         }
     }
 

--- a/Module/StreamXRef.psd1
+++ b/Module/StreamXRef.psd1
@@ -45,7 +45,7 @@
 
 First version released as a full PowerShell Module.
 
-* Renamed module to "StreamXRef" due to Twitch's limitiations on project names
+* Renamed module to "StreamXRef" due to Twitch's limitations on project names
 * Renamed `Get-TwitchXRef` to `Find-TwitchXRef`
 * Changed alias from `gtxr` to `txr`
 * Added data caching

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -127,7 +127,7 @@ catch {
 }
 
 # If the data file is found in the default location, automatically enable persistence
-if (Test-Path $PersistPath) {
+if ($PersistCanUse -and (Test-Path $PersistPath)) {
 
     Enable-XRefPersistence -Quiet
 

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -109,22 +109,20 @@ Export-ModuleMember -Function $FunctionNames
 
 #region Persistent data ========================
 
-$script:PersistStatus = [pscustomobject]@{
-    CanUse = $false
-    Enabled = $false
-    Id = 0
-}
+$script:PersistCanUse = $false
+$script:PersistEnabled = $false
+$script:PersistId = 0
 
 try {
 
     # Get path inside try/catch in case of problems resolving the path
     $script:PersistPath = Join-Path ([System.Environment]::GetFolderPath("ApplicationData")) "StreamXRef/datacache.json"
-    $script:PersistStatus.CanUse = $true
+    $script:PersistCanUse = $true
 
 }
 catch {
 
-    $script:PersistStatus.CanUse = $false
+    $script:PersistCanUse = $false
 
 }
 
@@ -137,8 +135,8 @@ if (Test-Path $PersistPath) {
 
 # Cleanup on unload
 $ExecutionContext.SessionState.Module.OnRemove += {
-    if ($PersistStatus.Id -ne 0) {
-        Unregister-Event -SubscriptionId $PersistStatus.Id -ErrorAction SilentlyContinue
+    if ($PersistId -ne 0) {
+        Unregister-Event -SubscriptionId $PersistId -ErrorAction SilentlyContinue
     }
 }
 

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -3,8 +3,14 @@ Set-StrictMode -Version 3
 # Add type data
 Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll"
 
-# Initialize cache (see comment at end of file for structure reference)
-$script:TwitchData = [StreamXRef.DataCache]::new()
+try {
+    # Initialize cache (see comment at end of file for structure reference)
+    $script:TwitchData = [StreamXRef.DataCache]::new()
+}
+catch {
+    throw "Unable to initialize StreamXRef data object"
+}
+
 
 #region Internal shared helper functions ================
 

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -1,3 +1,4 @@
+using namespace System.Collections.Generic
 Set-StrictMode -Version 3
 
 # Add type data
@@ -57,15 +58,16 @@ try {
 
     $script:TwitchData = [pscustomobject]@{
 
-        #   Value = [string] Client ID for API access
         ApiKey         = $null
+        #   Value = [string] Client ID for API access
 
+        UserInfoCache  = [Dictionary[string, int]]::new()
         <#
             Key   = [string] User/channel name
             Value = [int] User/channel ID number
         #>
-        UserInfoCache  = [System.Collections.Generic.Dictionary[string, int]]::new()
 
+        ClipInfoCache  = [Dictionary[string, pscustomobject]]::new()
         <#
             Key   = [string] Clip slug name
             Value = [pscustomobject]@{
@@ -78,13 +80,13 @@ try {
                 }
             }
         #>
-        ClipInfoCache  = [System.Collections.Generic.Dictionary[string, pscustomobject]]::new()
 
+        VideoInfoCache = [Dictionary[int, datetime]]::new()
         <#
             Key   = [int] Video ID number
             Value = [datetime] Starting timestamp in UTC
         #>
-        VideoInfoCache = [System.Collections.Generic.Dictionary[int, datetime]]::new()
+
 
     }
 

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -169,4 +169,6 @@ Structure of StreamXRef.DataCache:
     [dictionary]VideoInfoCache:
         Key   = [int] Video ID number
         Value = [datetime] Starting timestamp in UTC
+
+(All dictionaries use InvariantCultureIgnoreCase)
 #>

--- a/Module/StreamXRef.psm1
+++ b/Module/StreamXRef.psm1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version 3
 
 # Add type data
-Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll" -ErrorAction Stop
+Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll"
 
 # Initialize cache (see comment at end of file for structure reference)
 $script:TwitchData = [StreamXRef.DataCache]::new()

--- a/Tests/Base.Tests.ps1
+++ b/Tests/Base.Tests.ps1
@@ -123,3 +123,10 @@ Describe "Internal function validation" {
         }
     }
 }
+
+Describe "System environment" {
+    It "Application Data folder can be determined" {
+        {[System.Environment]::GetFolderPath("ApplicationData")} | Should -Not -Throw
+        [string]::IsNullOrWhiteSpace([System.Environment]::GetFolderPath("ApplicationData")) | Should -BeFalse
+    }
+}

--- a/Tests/Base.Tests.ps1
+++ b/Tests/Base.Tests.ps1
@@ -1,9 +1,9 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.2' }
 
 BeforeAll {
     Get-Module StreamXRef | Remove-Module
     $ProjectRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force -ErrorAction Stop
+    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force
 }
 
 Describe "Type loading" {

--- a/Tests/Base.Tests.ps1
+++ b/Tests/Base.Tests.ps1
@@ -7,6 +7,11 @@ BeforeAll {
 }
 
 Describe "Custom type data" {
+    BeforeAll {
+        # If one "Should" test fails, keep checking the rest in the "It" block
+        $PesterPreference = [PesterConfiguration]::Default
+        $PesterPreference.Should.ErrorAction = "Continue"
+    }
     Context "Constructors" {
         It "ImportCounter can be created" {
             {[StreamXRef.ImportCounter]::new("Test")} | Should -Not -Throw
@@ -26,45 +31,62 @@ Describe "Custom type data" {
     }
     Context "Members" {
         It "ImportCounter contains all properties" {
-            [StreamXRef.ImportCounter].DeclaredProperties.Name | ForEach-Object {
-                $_ | Should -BeIn Name, Imported, Skipped, Error, Total
-            }
+            $Properties = [StreamXRef.ImportCounter].DeclaredProperties.Name
+
+            $Properties | Should -Contain Name
+            $Properties | Should -Contain Imported
+            $Properties | Should -Contain Skipped
+            $Properties | Should -Contain Error
+            $Properties | Should -Contain Total
         }
         It "ImportResults contains all properties" {
-            [StreamXRef.ImportResults].DeclaredProperties.Name | ForEach-Object {
-                $_ | Should -BeIn AllImported, AllSkipped, AllError, AllTotal
-            }
+            $Properties = [StreamXRef.ImportResults].DeclaredProperties.Name
+
+            $Properties | Should -Contain AllImported
+            $Properties | Should -Contain AllSkipped
+            $Properties | Should -Contain AllError
+            $Properties | Should -Contain AllTotal
         }
         It "ImportResults contains AddCounter method" {
-            [StreamXRef.ImportResults].DeclaredMethods.Name | Should -Contain AddCounter
+            $Properties = [StreamXRef.ImportResults].DeclaredMethods.Name
+
+            $Properties | Should -Contain AddCounter
         }
         It "ClipObject contains all properties" {
-            [StreamXRef.ClipObject].DeclaredProperties.Name | ForEach-Object {
-                $_ | Should -BeIn Offset, VideoID, Created, Mapping
-            }
+            $Properties = [StreamXRef.ClipObject].DeclaredProperties.Name
+
+            $Properties | Should -Contain Offset
+            $Properties | Should -Contain VideoID
+            $Properties | Should -Contain Created
+            $Properties | Should -Contain Mapping
         }
         It "DataCache contains all properties" {
-            [StreamXRef.DataCache].DeclaredProperties.Name | ForEach-Object {
-                $_ | Should -BeIn ApiKey, UserInfoCache, ClipInfoCache, VideoInfoCache
-            }
+            $Properties = [StreamXRef.DataCache].DeclaredProperties.Name
+
+            $Properties | Should -Contain ApiKey
+            $Properties | Should -Contain UserInfoCache
+            $Properties | Should -Contain ClipInfoCache
+            $Properties | Should -Contain VideoInfoCache
         }
         It "DataCache contains GetTotalCount method" {
-            [StreamXRef.DataCache].DeclaredMethods.Name | Should -Contain GetTotalCount
+            $Properties = [StreamXRef.DataCache].DeclaredMethods.Name
+
+            $Properties | Should -Contain GetTotalCount
         }
     }
     Context "Functionality" {
         It "ImportCounter.Total sums all counter properties" {
             $TestObj = [StreamXRef.ImportCounter]::new("Test")
-
             $TestObj.Imported = 20
             $TestObj.Skipped = 4
             $TestObj.Error = 3
+
             $TestObj.Total | Should -Be 27
         }
         It "ImportResults.AddCounter(...) adds counter object" {
             $ResultObj = [StreamXRef.ImportResults]::new()
-
             $ResultObj.AddCounter("Test1")
+
             $ResultObj.Keys | Should -Contain "Test1"
             $ResultObj["Test1"] | Should -BeOfType "StreamXRef.ImportCounter"
         }

--- a/Tests/Export-XRefData.Tests.ps1
+++ b/Tests/Export-XRefData.Tests.ps1
@@ -1,9 +1,9 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.2' }
 
 BeforeAll {
     Get-Module StreamXRef | Remove-Module
     $ProjectRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force -ErrorAction Stop
+    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force
 }
 
 Describe "Export validation" {

--- a/Tests/Find-TwitchXRef.Tests.ps1
+++ b/Tests/Find-TwitchXRef.Tests.ps1
@@ -1,9 +1,9 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.2' }
 
 BeforeAll {
     Get-Module StreamXRef | Remove-Module
     $ProjectRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force -ErrorAction Stop
+    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force
     Import-Module Microsoft.PowerShell.Utility -Force
 
     function MakeMockHTTPError {

--- a/Tests/Import-XRefData.Tests.ps1
+++ b/Tests/Import-XRefData.Tests.ps1
@@ -1,9 +1,9 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.2' }
 
 BeforeAll {
     Get-Module StreamXRef | Remove-Module
     $ProjectRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force -ErrorAction Stop
+    Import-Module "$ProjectRoot/Module/StreamXRef.psd1" -Force
 }
 
 Describe "Import validation" {

--- a/docs/Import-XRefData.md
+++ b/docs/Import-XRefData.md
@@ -8,24 +8,25 @@ schema: 2.0.0
 # Import-XRefData
 
 ## SYNOPSIS
-Import data to the lookup cache. Can also set the API key without invoking a full lookup.
+Import data to the lookup cache.
 
 ## SYNTAX
 
 ### General (Default)
 ```
-Import-XRefData [-Path] <String> [-PassThru] [-Quiet] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-XRefData [-Path] <String> [-PassThru] [-Persist] [-Quiet] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### ApiKey
 ```
-Import-XRefData [-ApiKey] <String> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-XRefData [-ApiKey] <String> [-Persist] [-Quiet] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 This command lets you import data into the lookup cache from a JSON file that was made using `Export-XRefData`. If you use the `ApiKey` parameter, you can instead import just your API key from a string without having to invoke the main `Find-TwitchXRef` command.
 
-This command DOES NOT send an "**XRefNewDataAdded**" event.
+This command does not send an "**XRefNewDataAdded**" event by default.
 
 ## EXAMPLES
 
@@ -53,7 +54,6 @@ Name  Imported Skipped Error Total
 User         4      12     0    16
 Clip         7       2     0     9
 Video        5       1     0     6
-
 ```
 
 Save the results of importing and display them later as a table.
@@ -120,12 +120,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Persist
+Enables sending an **XRefNewDataAdded** event after new data is imported if there's a registered event subscriber (or if persistence is enabled).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Quiet
 Suppress writing import results to host as well as per-item warning messages (but not errors).
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: General
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/src/Clear-XRefData.ps1
+++ b/src/Clear-XRefData.ps1
@@ -17,16 +17,6 @@ function Clear-XRefData {
         [switch]$RemoveAll
     )
 
-    Begin {
-
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
-    }
-
     Process {
 
         if ($RemoveAll) {

--- a/src/Clear-XRefData.ps1
+++ b/src/Clear-XRefData.ps1
@@ -67,7 +67,7 @@ function Clear-XRefData {
                     [string[]]$PurgeList = $script:TwitchData.ClipInfoCache.GetEnumerator() |
                     Where-Object { $_.Value.Created -lt $Cutoff } | Select-Object -ExpandProperty Key
 
-                    [void]($PurgeList | ForEach-Object { $script:TwitchData.ClipInfoCache.Remove($_) })
+                    [void] ($PurgeList | ForEach-Object { $script:TwitchData.ClipInfoCache.Remove($_) })
 
                     # Getting the count this way in case removing an entry somehow fails
                     Write-Verbose "(Clip) Data entries removed: $($PreviousCount - $script:TwitchData.ClipInfoCache.Count)"
@@ -82,7 +82,7 @@ function Clear-XRefData {
                     [string[]]$PurgeList = $script:TwitchData.VideoInfoCache.GetEnumerator() |
                         Where-Object { $_.Value -lt $Cutoff } | Select-Object -ExpandProperty Key
 
-                    [void]($PurgeList | ForEach-Object { $script:TwitchData.VideoInfoCache.Remove($_) })
+                    [void] ($PurgeList | ForEach-Object { $script:TwitchData.VideoInfoCache.Remove($_) })
 
                     # Getting the count this way in case removing an entry somehow fails
                     Write-Verbose "(Video) Data entries removed: $($PreviousCount - $script:TwitchData.VideoInfoCache.Count)"

--- a/src/Disable-XRefPersistence.ps1
+++ b/src/Disable-XRefPersistence.ps1
@@ -12,7 +12,7 @@ function Disable-XRefPersistence {
 
     Process {
 
-        if ($PersistStatus.CanUse) {
+        if ($PersistCanUse) {
 
             if ($Remove) {
 
@@ -41,12 +41,12 @@ function Disable-XRefPersistence {
             }
 
             # Disable persistence subscriber
-            if ($PersistStatus.Id -ne 0) {
+            if ($PersistId -ne 0) {
 
-                Unregister-Event -SubscriptionId $PersistStatus.Id
+                Unregister-Event -SubscriptionId $PersistId
 
                 # Reset value
-                $script:PersistStatus.Id = 0
+                $script:PersistId = 0
 
                 if (-not $Quiet) {
                     Write-Host "StreamXRef persistence disabled."
@@ -54,7 +54,7 @@ function Disable-XRefPersistence {
 
             }
 
-            $script:PersistStatus.Enabled = $false
+            $script:PersistEnabled = $false
 
         }
         else {

--- a/src/Enable-XRefPersistence.ps1
+++ b/src/Enable-XRefPersistence.ps1
@@ -9,9 +9,9 @@ function Enable-XRefPersistence {
 
     Process {
 
-        if ($PersistStatus.CanUse) {
+        if ($PersistCanUse) {
 
-            if ($PersistStatus.Enabled) {
+            if ($PersistEnabled) {
 
                 if (-not $Quiet) {
                     Write-Host "StreamXRef persistence is already enabled."
@@ -58,9 +58,9 @@ function Enable-XRefPersistence {
                 })
 
                 # Take note of the subscription id (might not be the same as the PSEventJob id)
-                $script:PersistStatus.Id = (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded | Select-Object -Last 1).SubscriptionId
+                $script:PersistId = (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded | Select-Object -Last 1).SubscriptionId
 
-                $script:PersistStatus.Enabled = $true
+                $script:PersistEnabled = $true
 
                 if (-not $Quiet) {
                     Write-Host -BackgroundColor Black -ForegroundColor Green "StreamXRef persistence enabled."

--- a/src/Export-XRefData.ps1
+++ b/src/Export-XRefData.ps1
@@ -1,3 +1,4 @@
+using namespace System.Collections.Generic
 #.ExternalHelp StreamXRef-help.xml
 function Export-XRefData {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
@@ -47,6 +48,9 @@ function Export-XRefData {
 
         }
 
+        # DateTime string formatting ("yyyy-MM-ddTHH:mm:ssZ" -> "2020-05-09T05:35:45Z")
+        $DateTimeFormatting = "yyyy-MM-ddTHH:mm:ssZ"
+
         # Handle API key
         if ($ExcludeApiKey) {
             $ExportApiKey = ""
@@ -55,9 +59,9 @@ function Export-XRefData {
             $ExportApiKey = $script:TwitchData.ApiKey
         }
 
-        $ConvertedUserInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
-        $ConvertedClipInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
-        $ConvertedVideoInfoCache = [System.Collections.Generic.List[pscustomobject]]::new()
+        $ConvertedUserInfoCache = [List[pscustomobject]]::new()
+        $ConvertedClipInfoCache = [List[pscustomobject]]::new()
+        $ConvertedVideoInfoCache = [List[pscustomobject]]::new()
 
         # Convert UserInfoCache to List
         $script:TwitchData.UserInfoCache.GetEnumerator() | ForEach-Object {
@@ -74,7 +78,7 @@ function Export-XRefData {
         # Convert ClipInfoCache to List
         $script:TwitchData.ClipInfoCache.GetEnumerator() | ForEach-Object {
 
-            $ClipInfoMapping = [System.Collections.Generic.List[pscustomobject]]::new()
+            $ClipInfoMapping = [List[pscustomobject]]::new()
 
             if (-not $ExcludeClipMapping) {
                 # Convert clip mapping data to List
@@ -93,7 +97,7 @@ function Export-XRefData {
                     slug    = $_.Key
                     offset  = $_.Value.Offset
                     video   = $_.Value.VideoID
-                    created = $_.Value.Created.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                    created = $_.Value.Created.ToString($DateTimeFormatting)
                     mapping = $ClipInfoMapping
                 }
             )
@@ -103,11 +107,10 @@ function Export-XRefData {
         # Convert VideoInfoCache to List
         $script:TwitchData.VideoInfoCache.GetEnumerator() | ForEach-Object {
 
-            # ToString("yyyy-MM-ddTHH:mm:ssZ") specifies format like "2020-05-09T05:35:45Z"
             $ConvertedVideoInfoCache.Add(
                 [pscustomobject]@{
                     video     = $_.Key
-                    timestamp = $_.Value.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                    timestamp = $_.Value.ToString($DateTimeFormatting)
                 }
             )
 

--- a/src/Export-XRefData.ps1
+++ b/src/Export-XRefData.ps1
@@ -30,12 +30,6 @@ function Export-XRefData {
 
     Begin {
 
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         if ([string]::IsNullOrWhiteSpace($script:TwitchData.ApiKey) -and $script:TwitchData.GetTotalCount() -eq 0) {
 
             Write-Warning "No cached data. Exported file will not contain any entries."

--- a/src/Find-TwitchXRef.ps1
+++ b/src/Find-TwitchXRef.ps1
@@ -57,12 +57,6 @@ function Find-TwitchXRef {
 
     Begin {
 
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         $API = "https://api.twitch.tv/kraken"
 
         if ($PSBoundParameters.ContainsKey("ApiKey")) {

--- a/src/Find-TwitchXRef.ps1
+++ b/src/Find-TwitchXRef.ps1
@@ -615,7 +615,7 @@ function Find-TwitchXRef {
 
         if ((Get-EventSubscriber -SourceIdentifier XRefNewDataAdded -Force -ErrorAction Ignore) -and $NewDataAdded) {
 
-            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender StreamXRef)
+            [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender "Find-TwitchXRef")
 
         }
 

--- a/src/Find-TwitchXRef.ps1
+++ b/src/Find-TwitchXRef.ps1
@@ -113,10 +113,6 @@ function Find-TwitchXRef {
             ErrorAction = "Stop"
         }
 
-        # Standardize input to lowercase
-        $Source = $Source.ToLowerInvariant()
-        $XRef = $XRef.ToLowerInvariant()
-
         # Initial basic sorting
         #region @{ PSCodeSet = Current }
         $SourceIsVideo = $Source -imatch ".*twitch\.tv/videos/.+" ? $true : $false
@@ -257,20 +253,19 @@ function Find-TwitchXRef {
 
                     }
 
-                    # Populate the Clip to Username hashtable with the originating video
-                    $ClipMapping = @{}
-                    $ClipMapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
-
                     # Ensure timestamp was converted correctly
                     $ClipResponse.created_at = $ClipResponse.created_at | ConvertTo-UtcDateTime
 
                     # Add data to clip cache
-                    $script:TwitchData.ClipInfoCache[$Slug] = [PSCustomObject]@{
+                    $script:TwitchData.ClipInfoCache[$Slug] = [StreamXRef.ClipObject]@{
                         Offset  = $ClipResponse.vod.offset
                         VideoID = $VideoID
                         Created = $ClipResponse.created_at
-                        Mapping = $ClipMapping
                     }
+
+                    # Add mapping for originating video to clip entry
+                    $script:TwitchData.ClipInfoCache[$Slug].Mapping[$ClipResponse.broadcaster.name] = $ClipResponse.vod.url
+
                     $NewDataAdded = $true
 
                     # Quick return path for when XRef is original broadcaster

--- a/src/Find-TwitchXRef.ps1
+++ b/src/Find-TwitchXRef.ps1
@@ -178,7 +178,7 @@ function Find-TwitchXRef {
             }
             #endregion @{ PSCodeSet = Legacy }
 
-            [timespan]$TimeOffset = New-TimeSpan @OffsetArgs
+            $TimeOffset = New-TimeSpan @OffsetArgs
             #endregion
 
             [int]$VideoID = $Source | Get-LastUrlSegment
@@ -192,8 +192,6 @@ function Find-TwitchXRef {
             # Strip potential URL formatting
             $Slug = $Source | Get-LastUrlSegment
 
-            $tmpFlagCached = $false
-
             if (-not $Force -and $script:TwitchData.ClipInfoCache.ContainsKey($Slug)) {
                 # Found cached values to use
 
@@ -203,28 +201,18 @@ function Find-TwitchXRef {
                     return $script:TwitchData.ClipInfoCache[$Slug].Mapping[$XRef]
 
                 }
+                else {
 
-                try {
-
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
-                    [int]$VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
+                    $TimeOffset = New-TimeSpan -Seconds $script:TwitchData.ClipInfoCache[$Slug].Offset
+                    $VideoID = $script:TwitchData.ClipInfoCache[$Slug].VideoID
 
                     # Set REST arguments
                     $RestArgs["Uri"] = "$API/videos/$VideoID"
 
-                    $tmpFlagCached = $true
-
-                }
-                catch {
-
-                    # Suppress error output because the fallback will be to just look up the value again
-                    [void] $_
-
                 }
 
             }
-
-            if (-not $tmpFlagCached) {
+            else {
                 # New uncached source ---- needs additional API call
 
                 # Get information about clip
@@ -241,7 +229,7 @@ function Find-TwitchXRef {
                     }
 
                     # Get offset from API response
-                    [timespan]$TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
+                    $TimeOffset = New-TimeSpan -Seconds $ClipResponse.vod.offset
 
                     # Get Video ID from API response
                     [int]$VideoID = $ClipResponse.vod.id
@@ -313,7 +301,7 @@ function Find-TwitchXRef {
         if (-not $Force -and $script:TwitchData.VideoInfoCache.ContainsKey($VideoID)) {
 
             # Use start time from cache
-            [datetime]$EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
+            $EventTimestamp = $script:TwitchData.VideoInfoCache[$VideoID] + $TimeOffset
 
         }
         else {
@@ -421,7 +409,7 @@ function Find-TwitchXRef {
             if (-not $Force -and $script:TwitchData.UserInfoCache.ContainsKey($XRef)) {
 
                 # Get cached ID number
-                [int]$UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
+                $UserIdNum = $script:TwitchData.UserInfoCache[$XRef]
 
             }
             else {

--- a/src/Find-TwitchXRef.ps1
+++ b/src/Find-TwitchXRef.ps1
@@ -163,7 +163,7 @@ function Find-TwitchXRef {
             }
 
             #region Get offset from URL parameters
-            [void]($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
+            [void] ($Source -imatch ".*[?&]t=((?<Hours>\d+)h)?((?<Minutes>\d+)m)?((?<Seconds>\d+)s)?.*")
 
             #region @{ PSCodeSet = Current }
             $OffsetArgs = @{ }
@@ -228,7 +228,7 @@ function Find-TwitchXRef {
                 catch {
 
                     # Suppress error output because the fallback will be to just look up the value again
-                    [void]$_
+                    [void] $_
 
                 }
 

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -30,13 +30,6 @@ function Import-XRefData {
 
         }
 
-        # Check for required resources
-        if (-not (Test-Path Variable:Script:TwitchData)) {
-
-            throw "Missing required internal resources. Ensure module was loaded correctly."
-
-        }
-
         $MappingWarning = $false
         $ConflictingData = $false
 
@@ -53,21 +46,11 @@ function Import-XRefData {
             # This will now terminate the script if it fails
             $ConfigStaging = Get-Content $Path -Raw | ConvertFrom-Json
 
-            if ($AdvImportCounter) {
-                # Set up counters object
-                $Counters = [StreamXRef.ImportResults]::new()
-                $Counters.AddCounter("User")
-                $Counters.AddCounter("Clip")
-                $Counters.AddCounter("Video")
-            }
-            else {
-                # Basic fallback object
-                $Counters = @{
-                    User = [pscustomobject]@{Name = "User"; Imported = 0; Skipped = 0; Error = 0}
-                    Clip = [pscustomobject]@{Name = "Clip"; Imported = 0; Skipped = 0; Error = 0}
-                    Video = [pscustomobject]@{Name = "Video"; Imported = 0; Skipped = 0; Error = 0}
-                }
-            }
+            # Set up counters object
+            $Counters = [StreamXRef.ImportResults]::new()
+            $Counters.AddCounter("User")
+            $Counters.AddCounter("Clip")
+            $Counters.AddCounter("Video")
 
             # Restore ErrorActionPreference
             $ErrorActionPreference = $EAPrefSetting
@@ -469,8 +452,7 @@ function Import-XRefData {
 
             if (-not $Quiet) {
 
-                # Display import results (manual ordering in case of unordered fallback object)
-                ($Counters.User, $Counters.Clip, $Counters.Video) | Format-Table -AutoSize | Out-Host
+                $Counters.Values| Format-Table -AutoSize | Out-Host
 
             }
 

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -44,7 +44,7 @@ function Import-XRefData {
             $ErrorActionPreference = "Stop"
 
             # This will now terminate the script if it fails
-            $ConfigStaging = Get-Content $Path -Raw | ConvertFrom-Json
+            $ImportStaging = Get-Content $Path -Raw | ConvertFrom-Json
 
             # Set up counters object
             $Counters = [StreamXRef.ImportResults]::new()
@@ -58,7 +58,7 @@ function Import-XRefData {
         }
 
         # Process ApiKey (Check parameter set first since ConfigStaging won't exist in the ApiKey set)
-        if ($PSCmdlet.ParameterSetName -eq "ApiKey" -or ($ConfigStaging.psobject.Properties.Name -contains "ApiKey" -and -not [string]::IsNullOrWhiteSpace($ConfigStaging.ApiKey))) {
+        if ($PSCmdlet.ParameterSetName -eq "ApiKey" -or ($ImportStaging.psobject.Properties.Name -contains "ApiKey" -and -not [string]::IsNullOrWhiteSpace($ImportStaging.ApiKey))) {
 
             # Check if current API key is not set
             if ([string]::IsNullOrWhiteSpace($script:TwitchData.ApiKey)) {
@@ -84,7 +84,7 @@ function Import-XRefData {
                     else {
 
                         # Import API key from input object
-                        $script:TwitchData.ApiKey = $ConfigStaging.ApiKey
+                        $script:TwitchData.ApiKey = $ImportStaging.ApiKey
 
                         if (-not $Quiet) {
 
@@ -154,12 +154,12 @@ function Import-XRefData {
         }
 
         # Process UserInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "UserInfoCache" -and $ConfigStaging.UserInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "UserInfoCache" -and $ImportStaging.UserInfoCache.Count -gt 0) {
 
             # Check for confirm status here instead of for every single entry
             if ($PSCmdlet.ShouldProcess("User ID lookup data", "Import")) {
 
-                $ConfigStaging.UserInfoCache | ForEach-Object {
+                $ImportStaging.UserInfoCache | ForEach-Object {
 
                     try {
 
@@ -237,11 +237,11 @@ function Import-XRefData {
         }
 
         # Process ClipInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "ClipInfoCache" -and $ConfigStaging.ClipInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "ClipInfoCache" -and $ImportStaging.ClipInfoCache.Count -gt 0) {
 
             if ($PSCmdlet.ShouldProcess("Clip info lookup data", "Import")) {
 
-                $ConfigStaging.ClipInfoCache | ForEach-Object {
+                $ImportStaging.ClipInfoCache | ForEach-Object {
 
                     try {
 
@@ -346,11 +346,11 @@ function Import-XRefData {
         }
 
         # Process VideoInfoCache
-        if ($ConfigStaging.psobject.Properties.Name -contains "VideoInfoCache" -and $ConfigStaging.VideoInfoCache.Count -gt 0) {
+        if ($ImportStaging.psobject.Properties.Name -contains "VideoInfoCache" -and $ImportStaging.VideoInfoCache.Count -gt 0) {
 
             if ($PSCmdlet.ShouldProcess("Video timestamp lookup data", "Import")) {
 
-                $ConfigStaging.VideoInfoCache | ForEach-Object {
+                $ImportStaging.VideoInfoCache | ForEach-Object {
 
                     try {
 

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -16,6 +16,9 @@ function Import-XRefData {
         [switch]$PassThru,
 
         [Parameter()]
+        [switch]$Persist,
+
+        [Parameter()]
         [switch]$Quiet,
 
         [Parameter()]
@@ -442,6 +445,16 @@ function Import-XRefData {
             if (-not $Quiet) {
 
                 $Counters.Values| Format-Table -AutoSize | Out-Host
+
+            }
+
+            if ($Persist -and $Counters.AllImported -gt 0) {
+
+                if (Get-EventSubscriber -SourceIdentifier XRefNewDataAdded -Force -ErrorAction Ignore) {
+
+                    [void] (New-Event -SourceIdentifier XRefNewDataAdded -Sender "Import-XRefData")
+
+                }
 
             }
 

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -278,7 +278,7 @@ function Import-XRefData {
                                 if ($Force) {
 
                                     # Overwrite
-                                    $script:TwitchData.ClipInfoCache[$_.slug] = [pscustomobject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
+                                    $script:TwitchData.ClipInfoCache[$_.slug] = [StreamXRef.ClipObject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
                                     $Counters.Clip.Imported++
 
                                 }
@@ -305,7 +305,7 @@ function Import-XRefData {
                         else {
 
                             # New data to add
-                            $script:TwitchData.ClipInfoCache[$_.slug] = [pscustomobject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
+                            $script:TwitchData.ClipInfoCache[$_.slug] = [StreamXRef.ClipObject]@{ Offset = $NewOffsetValue; VideoID = $NewVideoIDValue; Created = $ConvertedDateTime; Mapping = @{} }
                             $Counters.Clip.Imported++
 
                         }

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -119,28 +119,17 @@ function Import-XRefData {
                     # Specify "Replace" since previous value will be replaced
                     if ($PSCmdlet.ShouldProcess("API key", "Replace")) {
 
-                        if ($PSCmdlet.ParameterSetName -eq "ApiKey") {
+                        $script:TwitchData.ApiKey = $NewApiKey
 
-                            $script:TwitchData.ApiKey = $NewApiKey
+                        if (-not $Quiet) {
 
-                            if (-not $Quiet) {
-
-                                Write-Host "API key replaced."
-
-                            }
-
-                            return
+                            Write-Host "API key replaced."
 
                         }
-                        else {
 
-                            $script:TwitchData.ApiKey = $NewApiKey
+                        if ($PSCmdlet.ParameterSetName -eq "ApiKey") {
 
-                            if (-not $Quiet) {
-
-                                Write-Host "API key replaced."
-
-                            }
+                            return
 
                         }
 

--- a/src/Import-XRefData.ps1
+++ b/src/Import-XRefData.ps1
@@ -109,7 +109,7 @@ function Import-XRefData {
                 else {
 
                     # Get key from input object
-                    $NewApiKey = $ConfigStaging.ApiKey
+                    $NewApiKey = $ImportStaging.ApiKey
 
                 }
 

--- a/src/StreamXRef.psd1
+++ b/src/StreamXRef.psd1
@@ -52,7 +52,7 @@ First version released as a full PowerShell Module.
 * Added `Export-XRefData`, `Import-XRefData`, `Clear-XRefData`, `Enable-XRefPersistence`, and `Disable-XRefPersistence`
 '@
 
-            Prerelease = 'beta7'
+            Prerelease = 'beta8'
         }
     }
 

--- a/src/StreamXRef.psd1
+++ b/src/StreamXRef.psd1
@@ -45,7 +45,7 @@
 
 First version released as a full PowerShell Module.
 
-* Renamed module to "StreamXRef" due to Twitch's limitiations on project names
+* Renamed module to "StreamXRef" due to Twitch's limitations on project names
 * Renamed `Get-TwitchXRef` to `Find-TwitchXRef`
 * Changed alias from `gtxr` to `txr`
 * Added data caching

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -127,7 +127,7 @@ catch {
 }
 
 # If the data file is found in the default location, automatically enable persistence
-if (Test-Path $PersistPath) {
+if ($PersistCanUse -and (Test-Path $PersistPath)) {
 
     Enable-XRefPersistence -Quiet
 

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -109,22 +109,20 @@ Export-ModuleMember -Function $FunctionNames
 
 #region Persistent data ========================
 
-$script:PersistStatus = [pscustomobject]@{
-    CanUse = $false
-    Enabled = $false
-    Id = 0
-}
+$script:PersistCanUse = $false
+$script:PersistEnabled = $false
+$script:PersistId = 0
 
 try {
 
     # Get path inside try/catch in case of problems resolving the path
     $script:PersistPath = Join-Path ([System.Environment]::GetFolderPath("ApplicationData")) "StreamXRef/datacache.json"
-    $script:PersistStatus.CanUse = $true
+    $script:PersistCanUse = $true
 
 }
 catch {
 
-    $script:PersistStatus.CanUse = $false
+    $script:PersistCanUse = $false
 
 }
 
@@ -137,8 +135,8 @@ if (Test-Path $PersistPath) {
 
 # Cleanup on unload
 $ExecutionContext.SessionState.Module.OnRemove += {
-    if ($PersistStatus.Id -ne 0) {
-        Unregister-Event -SubscriptionId $PersistStatus.Id -ErrorAction SilentlyContinue
+    if ($PersistId -ne 0) {
+        Unregister-Event -SubscriptionId $PersistId -ErrorAction SilentlyContinue
     }
 }
 

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -3,8 +3,14 @@ Set-StrictMode -Version 3
 # Add type data
 Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll"
 
-# Initialize cache (see comment at end of file for structure reference)
-$script:TwitchData = [StreamXRef.DataCache]::new()
+try {
+    # Initialize cache (see comment at end of file for structure reference)
+    $script:TwitchData = [StreamXRef.DataCache]::new()
+}
+catch {
+    throw "Unable to initialize StreamXRef data object"
+}
+
 
 #region Internal shared helper functions ================
 

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -1,3 +1,4 @@
+using namespace System.Collections.Generic
 Set-StrictMode -Version 3
 
 # Add type data
@@ -57,15 +58,16 @@ try {
 
     $script:TwitchData = [pscustomobject]@{
 
-        #   Value = [string] Client ID for API access
         ApiKey         = $null
+        #   Value = [string] Client ID for API access
 
+        UserInfoCache  = [Dictionary[string, int]]::new()
         <#
             Key   = [string] User/channel name
             Value = [int] User/channel ID number
         #>
-        UserInfoCache  = [System.Collections.Generic.Dictionary[string, int]]::new()
 
+        ClipInfoCache  = [Dictionary[string, pscustomobject]]::new()
         <#
             Key   = [string] Clip slug name
             Value = [pscustomobject]@{
@@ -78,13 +80,13 @@ try {
                 }
             }
         #>
-        ClipInfoCache  = [System.Collections.Generic.Dictionary[string, pscustomobject]]::new()
 
+        VideoInfoCache = [Dictionary[int, datetime]]::new()
         <#
             Key   = [int] Video ID number
             Value = [datetime] Starting timestamp in UTC
         #>
-        VideoInfoCache = [System.Collections.Generic.Dictionary[int, datetime]]::new()
+
 
     }
 

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -169,4 +169,6 @@ Structure of StreamXRef.DataCache:
     [dictionary]VideoInfoCache:
         Key   = [int] Video ID number
         Value = [datetime] Starting timestamp in UTC
+
+(All dictionaries use InvariantCultureIgnoreCase)
 #>

--- a/src/StreamXRef.psm1
+++ b/src/StreamXRef.psm1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version 3
 
 # Add type data
-Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll" -ErrorAction Stop
+Add-Type -Path "$PSScriptRoot/typedata/StreamXRefTypes.dll"
 
 # Initialize cache (see comment at end of file for structure reference)
 $script:TwitchData = [StreamXRef.DataCache]::new()

--- a/src/dotnet/DataCache.cs
+++ b/src/dotnet/DataCache.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace StreamXRef
+{
+    public class ClipObject
+    {
+        public int Offset { get; set; }
+        public int VideoID { get; set; }
+        public DateTime Created { get; set; }
+        public Dictionary<String, String> Mapping { get; set; }
+
+        public ClipObject()
+        {
+            Mapping = new Dictionary<String, String>(StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+
+    public class DataCache
+    {
+        public string ApiKey { get; set; }
+        public Dictionary<String, Int32> UserInfoCache { get; set; }
+        public Dictionary<String, ClipObject> ClipInfoCache { get; set; }
+        public Dictionary<Int32, DateTime> VideoInfoCache { get; set; }
+
+        public int GetTotalCount() => UserInfoCache.Count + ClipInfoCache.Count + VideoInfoCache.Count;
+
+        public DataCache()
+        {
+            ApiKey = "";
+            UserInfoCache = new Dictionary<String, Int32>(StringComparer.InvariantCultureIgnoreCase);
+            ClipInfoCache = new Dictionary<String, ClipObject>(StringComparer.InvariantCultureIgnoreCase);
+            VideoInfoCache = new Dictionary<Int32, DateTime>();
+        }
+    }
+}

--- a/src/dotnet/DataCache.cs
+++ b/src/dotnet/DataCache.cs
@@ -3,19 +3,6 @@ using System.Collections.Generic;
 
 namespace StreamXRef
 {
-    public class ClipObject
-    {
-        public int Offset { get; set; }
-        public int VideoID { get; set; }
-        public DateTime Created { get; set; }
-        public Dictionary<String, String> Mapping { get; set; }
-
-        public ClipObject()
-        {
-            Mapping = new Dictionary<String, String>(StringComparer.InvariantCultureIgnoreCase);
-        }
-    }
-
     public class DataCache
     {
         public string ApiKey { get; set; }
@@ -31,6 +18,19 @@ namespace StreamXRef
             UserInfoCache = new Dictionary<String, Int32>(StringComparer.InvariantCultureIgnoreCase);
             ClipInfoCache = new Dictionary<String, ClipObject>(StringComparer.InvariantCultureIgnoreCase);
             VideoInfoCache = new Dictionary<Int32, DateTime>();
+        }
+    }
+
+    public class ClipObject
+    {
+        public int Offset { get; set; }
+        public int VideoID { get; set; }
+        public DateTime Created { get; set; }
+        public Dictionary<String, String> Mapping { get; set; }
+
+        public ClipObject()
+        {
+            Mapping = new Dictionary<String, String>(StringComparer.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/dotnet/ImportResults.cs
+++ b/src/dotnet/ImportResults.cs
@@ -3,25 +3,6 @@ using System.Collections.Generic;
 
 namespace StreamXRef
 {
-    public class ImportCounter
-    {
-        public string Name { get; set; }
-        public int Imported { get; set; }
-        public int Skipped { get; set; }
-        public int Error { get; set; }
-        public int Total { get => Imported + Skipped + Error; }
-
-        public ImportCounter(string name)
-        {
-            Name = name;
-            Imported = 0;
-            Skipped = 0;
-            Error = 0;
-        }
-
-        public override string ToString() => ("Imported: " + Imported + ", Skipped: " + Skipped + ", Error: " + Error + ", Total: " + Total);
-    }
-
     public class ImportResults : Dictionary<String, ImportCounter>
     {
         public void AddCounter(string name) => this.Add(name, new ImportCounter(name));
@@ -105,5 +86,24 @@ namespace StreamXRef
                 }
             }
         }
+    }
+
+    public class ImportCounter
+    {
+        public string Name { get; set; }
+        public int Imported { get; set; }
+        public int Skipped { get; set; }
+        public int Error { get; set; }
+        public int Total { get => Imported + Skipped + Error; }
+
+        public ImportCounter(string name)
+        {
+            Name = name;
+            Imported = 0;
+            Skipped = 0;
+            Error = 0;
+        }
+
+        public override string ToString() => ("Imported: " + Imported + ", Skipped: " + Skipped + ", Error: " + Error + ", Total: " + Total);
     }
 }

--- a/src/dotnet/ImportStats.cs
+++ b/src/dotnet/ImportStats.cs
@@ -9,13 +9,7 @@ namespace StreamXRef
         public int Imported { get; set; }
         public int Skipped { get; set; }
         public int Error { get; set; }
-        public int Total
-        {
-            get
-            {
-                return (Imported + Skipped + Error);
-            }
-        }
+        public int Total { get => Imported + Skipped + Error; }
 
         public ImportCounter(string name)
         {

--- a/src/dotnet/StreamXRefTypes.csproj
+++ b/src/dotnet/StreamXRefTypes.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>StreamXRefTypes</AssemblyName>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Improved data type enforcement (data cache layout now specified in the class library).
- Added `Persist` parameter to `Import-XRefData` to enable emitting an event when new data is imported.
- The "XRefNewDataAdded" event now specifies whether the sender is `Find-TwitchXRef` or `Import-XRefData`.
- Code cleanup.
- Fixed property checking in base tests.
- Update minimum Pester version to 5.0.2.